### PR TITLE
Fix dashboard overflow and use full viewport width

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,10 +1,3 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
-
 .logo {
   height: 6em;
   padding: 1.5em;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,10 @@ import React, { useEffect, useMemo, useState } from "react";
  * - No max stage count; scroll appears inside card if too many
  * - “+” only for Add Bit button
  * - Zoom view centers a single song on a pure black background; UI is the same but enlarged
+ *
+ * Album Progress Dashboard - v4
+ * Changes in this pass:
+ * - Fix some screen size issues
  */
 
 const DEFAULT_STAGE_NAMES = [
@@ -530,7 +534,7 @@ export default function App() {
 	  }, [albumTitle]);
 	  
   return (
-    <div className="min-h-screen w-full bg-neutral-950 text-neutral-100 overflow-x-auto">  
+    <div className="min-h-screen w-full bg-neutral-950 text-neutral-100 overflow-x-auto">
 
       {currentSong ? (
 		  <SongDetail

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -357,7 +357,7 @@ function SongCard({ song, onUpdate, onZoom }) {
   const addStage = () => onUpdate({ ...song, stages: [...song.stages, { name: `Stage ${song.stages.length + 1}`, value: 0 }] });
 
   return (
-		   <div className="bg-neutral-900 border border-neutral-800 rounded-2xl shadow-sm p-2 flex flex-col gap-2 h-[232px] w-[376px]">
+                   <div className="bg-neutral-900 border border-neutral-800 ... h-[232px] w-full max-w-sm"> 
 		  <div className="flex items-center justify-between gap-2">
 			<EditableText
 			  text={song.title}
@@ -530,8 +530,7 @@ export default function App() {
 	  }, [albumTitle]);
 	  
   return (
-    <div className="h-screen w-full overflow-hidden bg-neutral-950 text-neutral-100">
-      
+    <div className="min-h-screen w-full bg-neutral-950 text-neutral-100 overflow-x-auto">  
 
       {currentSong ? (
 		  <SongDetail
@@ -563,8 +562,8 @@ export default function App() {
 			  </span>
 			</div>
 
-			<div className="px-4 pb-4 h-[calc(100vh-140px)] overflow-hidden">
-			  <div className="grid grid-cols-5 gap-1 justify-items-center">
+			<div className="px-4 pb-4 h-[calc(100vh-140px)] overflow-auto">  
+                          <div className="grid gap-3 justify-items-stretch xl:grid-cols-5 lg:grid-cols-4 md:grid-cols-3 sm:grid-cols-2 grid-cols-1">
 				{songs.map((song) => (
 				  <SongCard
 					key={song.id}

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,15 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+html,
+body,
+#root {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+}
+
 a {
   font-weight: 500;
   color: #646cff;
@@ -28,6 +37,7 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background-color: #020617;
 }
 
 h1 {


### PR DESCRIPTION
## Summary

On smaller laptop screens the dashboard was constrained to a narrow area and "squished." This PR addresses this issue and allows the content to fit on smaller screens.

## Changes

- Removed the Vite starter `#root` styles that set `max-width: 1280px` and centered the app.
- Reset global layout so `html`, `body`, and `#root` have no margins/padding and can fill the viewport.
- Matched the page background to the app’s dark background so there’s no visible gutter.

## Testing

- Safari (macOS)
- Chrome (macOS)

Thanks for sharing this project! I’m using it to track my own album and this tweak makes it fit my screen better. I've got a few features in mind that I might try to implement and send your way if you're open to it. 